### PR TITLE
Fix pointer index type in native input handler

### DIFF
--- a/app/src/main/cpp/Renderer.cpp
+++ b/app/src/main/cpp/Renderer.cpp
@@ -452,9 +452,11 @@ void Renderer::handleInput() {
             continue;
         }
         const auto action = motionEvent.action & AMOTION_EVENT_ACTION_MASK;
-        auto pointerIndex = (motionEvent.action & AMOTION_EVENT_ACTION_POINTER_INDEX_MASK)
-                >> AMOTION_EVENT_ACTION_POINTER_INDEX_SHIFT;
-        pointerIndex = std::min(pointerIndex, motionEvent.pointerCount - 1);
+        const size_t pointerCount = static_cast<size_t>(motionEvent.pointerCount);
+        auto pointerIndex = static_cast<size_t>(
+                (motionEvent.action & AMOTION_EVENT_ACTION_POINTER_INDEX_MASK)
+                >> AMOTION_EVENT_ACTION_POINTER_INDEX_SHIFT);
+        pointerIndex = std::min(pointerIndex, pointerCount - 1);
         const auto &pointer = motionEvent.pointers[pointerIndex];
         const float x = GameActivityPointerAxes_getX(&pointer);
         const float y = GameActivityPointerAxes_getY(&pointer);


### PR DESCRIPTION
## Summary
- ensure the motion event pointer index is tracked using size_t
- adjust the min comparison to avoid signed/unsigned mismatches when clamping the pointer index

## Testing
- ./gradlew :app:externalNativeBuildDebug *(fails: Unable to tunnel through proxy. Proxy returns "HTTP/1.1 403 Forbidden")*

------
https://chatgpt.com/codex/tasks/task_e_68d95aaef49c8329b5fd0b7868d60d9d