### PR TITLE
Wrap snake movement around grid edges

### DIFF
--- a/app/src/main/cpp/Renderer.cpp
+++ b/app/src/main/cpp/Renderer.cpp
@@ -381,8 +381,22 @@ void Renderer::advanceSnake() {
             break;
     }
 
-    const bool hitWall = newHead.x < 0 || newHead.y < 0
-            || newHead.x >= gridWidth_ || newHead.y >= gridHeight_;
+    if (gridWidth_ > 0) {
+        if (newHead.x < 0) {
+            newHead.x = gridWidth_ - 1;
+        } else if (newHead.x >= gridWidth_) {
+            newHead.x = 0;
+        }
+    }
+
+    if (gridHeight_ > 0) {
+        if (newHead.y < 0) {
+            newHead.y = gridHeight_ - 1;
+        } else if (newHead.y >= gridHeight_) {
+            newHead.y = 0;
+        }
+    }
+
     const bool hitSelf = std::any_of(
             snake_.begin(),
             snake_.end(),
@@ -390,7 +404,7 @@ void Renderer::advanceSnake() {
                 return segment.x == newHead.x && segment.y == newHead.y;
             });
 
-    if (hitWall || hitSelf) {
+    if (hitSelf) {
         resetGame();
         return;
     }


### PR DESCRIPTION
## Summary
- wrap the snake position to the opposite edge when it moves beyond the grid bounds
- retain collision detection with the snake body while allowing seamless edge traversal

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d95edb8ffc832987c5c3cc405fea11