### PR TITLE
Add AI-controlled bot snake

### DIFF
--- a/app/src/main/cpp/Renderer.h
+++ b/app/src/main/cpp/Renderer.h
@@ -77,6 +77,10 @@ private:
     void spawnFood();
     bool rebuildModels();
     void advanceSnake();
+    bool advanceBotSnake(Direction &botDirection);
+    Direction chooseBotDirection() const;
+    Cell computeNextCell(const Cell &current, Direction direction) const;
+    bool isCellOccupiedBySnake(const Cell &cell, const std::vector<Cell> &snake) const;
     void queueDirection(Direction direction);
     static bool isOpposite(Direction lhs, Direction rhs);
     void handleSwipe(float startX, float startY, float endX, float endY);
@@ -96,11 +100,14 @@ private:
     int gridWidth_ = 20;
     int gridHeight_ = 20;
     std::vector<Cell> snake_;
+    std::vector<Cell> botSnake_;
     Cell food_{};
     Direction direction_ = Direction::Right;
     Direction queuedDirection_ = Direction::Right;
+    Direction botDirection_ = Direction::Left;
     std::shared_ptr<TextureAsset> snakeTexture_;
     std::shared_ptr<TextureAsset> foodTexture_;
+    std::shared_ptr<TextureAsset> botTexture_;
     std::mt19937 randomEngine_;
     std::chrono::steady_clock::time_point lastFrameTime_;
     double timeAccumulator_ = 0.0;


### PR DESCRIPTION
## Summary
- add a second AI-controlled snake that pursues the shared food
- render the bot snake with its own color and keep food spawning off either snake
- share grid helpers so both snakes wrap correctly and trigger resets on collisions

## Testing
- ./gradlew assembleDebug *(fails: Android SDK not installed in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d96cfb93988329917a9bc54281365f