### PR TITLE
Move controller overlay to bottom right corner

### DIFF
--- a/app/src/main/res/layout/controller_overlay.xml
+++ b/app/src/main/res/layout/controller_overlay.xml
@@ -9,9 +9,10 @@
     <LinearLayout
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:layout_gravity="bottom|center_horizontal"
+        android:layout_gravity="bottom|end"
         android:layout_marginBottom="24dp"
-        android:gravity="center"
+        android:layout_marginEnd="24dp"
+        android:gravity="end"
         android:orientation="vertical"
         android:alpha="0.85">
 


### PR DESCRIPTION
## Summary
- update the controller overlay layout gravity to align with the bottom-right corner
- add right margin and adjust gravity so the on-screen controls sit away from the edge

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d97a6c9fe08329acb603a0aab1b5ed