### PR TITLE
Adjust controller overlay arrow layout

### DIFF
--- a/app/src/main/res/layout/controller_overlay.xml
+++ b/app/src/main/res/layout/controller_overlay.xml
@@ -12,27 +12,22 @@
         android:layout_gravity="bottom|end"
         android:layout_marginBottom="24dp"
         android:layout_marginEnd="24dp"
+        android:alpha="0.85"
         android:gravity="end"
-        android:orientation="vertical"
-        android:alpha="0.85">
+        android:orientation="vertical">
+
+        <Button
+            android:id="@+id/buttonUp"
+            android:layout_width="64dp"
+            android:layout_height="64dp"
+            android:layout_gravity="center_horizontal"
+            android:text="↑"
+            android:textSize="24sp" />
 
         <LinearLayout
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:gravity="center"
-            android:orientation="horizontal">
-
-            <Button
-                android:id="@+id/buttonUp"
-                android:layout_width="64dp"
-                android:layout_height="64dp"
-                android:text="↑"
-                android:textSize="24sp" />
-        </LinearLayout>
-
-        <LinearLayout
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
+            android:layout_gravity="center_horizontal"
             android:layout_marginTop="8dp"
             android:layout_marginBottom="8dp"
             android:gravity="center"
@@ -50,23 +45,20 @@
                 android:layout_height="match_parent" />
 
             <Button
-                android:id="@+id/buttonDown"
-                android:layout_width="64dp"
-                android:layout_height="64dp"
-                android:text="↓"
-                android:textSize="24sp" />
-
-            <View
-                android:layout_width="16dp"
-                android:layout_height="match_parent" />
-
-            <Button
                 android:id="@+id/buttonRight"
                 android:layout_width="64dp"
                 android:layout_height="64dp"
                 android:text="→"
                 android:textSize="24sp" />
         </LinearLayout>
+
+        <Button
+            android:id="@+id/buttonDown"
+            android:layout_width="64dp"
+            android:layout_height="64dp"
+            android:layout_gravity="center_horizontal"
+            android:text="↓"
+            android:textSize="24sp" />
     </LinearLayout>
 
 </FrameLayout>


### PR DESCRIPTION
## Summary
- center the up button above the other controls so it sits directly above the down button
- keep the left and right buttons on a middle row between the vertical arrows for a clearer D-pad layout

## Testing
- not run (UI change only)

------
https://chatgpt.com/codex/tasks/task_e_68d97d47a26c8329b74e2e7ba2621245