### PR TITLE
Spawn multiple food pickups for snakes

### DIFF
--- a/app/src/main/cpp/Renderer.h
+++ b/app/src/main/cpp/Renderer.h
@@ -101,7 +101,7 @@ private:
     int gridHeight_ = 100;
     std::vector<Cell> snake_;
     std::vector<Cell> botSnake_;
-    Cell food_{};
+    std::vector<Cell> food_;
     Direction direction_ = Direction::Right;
     Direction queuedDirection_ = Direction::Right;
     Direction botDirection_ = Direction::Left;
@@ -116,6 +116,7 @@ private:
     bool touchActive_ = false;
     float touchStartX_ = 0.f;
     float touchStartY_ = 0.f;
+    size_t targetFoodCount_ = 3;
 };
 
 #endif //ANDROIDGLINVESTIGATIONS_RENDERER_H


### PR DESCRIPTION
## Summary
- allow the renderer to maintain several food cells at once and replenish them after they are eaten
- update rendering and game logic to handle multiple food pickups and adjust bot pathing toward the nearest target

## Testing
- ./gradlew test *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68d97f4b200c8329b12a2edcb6ffd100